### PR TITLE
Improve 'php artisan bump' CLI

### DIFF
--- a/scripts/version/semver.sh
+++ b/scripts/version/semver.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Base directory containing source code
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Determine if the version bump is a major, minor or patch
+while :; do
+    case $1 in
+        -ma|--major) type="major"
+        ;;
+        -mi|--minor) type="minor"
+        ;;
+        -p|--patch) type="patch"
+        ;;
+        *) break
+    esac
+    shift
+done
+
+# Retrieve the version number
+VERSION="$(head -n 1 version.txt)"
+
+# Get the new version number
+# https://github.com/fsaintjacques/semver-tool
+BUMP="$(${DIR}/semver bump ${type} ${VERSION})"
+
+echo "${BUMP}"

--- a/src/Commands/Bump.php
+++ b/src/Commands/Bump.php
@@ -5,6 +5,7 @@ namespace Sfneal\Cruise\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Support\Facades\Process;
+use Sfneal\Helpers\Laravel\AppInfo;
 use function Laravel\Prompts\select;
 
 class Bump extends Command implements PromptsForMissingInput
@@ -29,10 +30,32 @@ class Bump extends Command implements PromptsForMissingInput
     protected $description = 'Bump the application to the next major, minor or patch version';
 
     /**
+     * The current application version
+     *
+     * @var string
+     */
+    protected string $version;
+
+    /**
+     * Create a new console command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->version = AppInfo::version();
+    }
+
+    /**
      * Execute the console command.
      */
     public function handle(): int
     {
+        // Get the current app version
+        $this->info("Current application version: {$this->version}");
+
         // Run bump command
         $bumpProcess = Process::path(base_path())->run([
             'bash', $this->getScriptPath('bump.sh'),

--- a/src/Commands/Bump.php
+++ b/src/Commands/Bump.php
@@ -45,7 +45,7 @@ class Bump extends Command implements PromptsForMissingInput
     {
         parent::__construct();
 
-        $this->version = AppInfo::version();
+        $this->version = Version::get();
     }
 
     /**

--- a/src/Commands/Bump.php
+++ b/src/Commands/Bump.php
@@ -53,9 +53,6 @@ class Bump extends Command implements PromptsForMissingInput
      */
     public function handle(): int
     {
-        // Get the current app version
-        $this->info("Current application version: {$this->version}");
-
         // Run bump command
         $bumpProcess = Process::path(base_path())->run([
             'bash', $this->getScriptPath('bump.sh'),
@@ -93,6 +90,9 @@ class Bump extends Command implements PromptsForMissingInput
     {
         return [
             'type' => function() {
+                // Display table with bump options
+                $this->displaySemverOptions();
+
                 return select(
                     label: 'Which semver segment would you like to bump?',
                     options: self::TYPES,
@@ -116,5 +116,26 @@ class Bump extends Command implements PromptsForMissingInput
     private function isCommitDisabled(): bool
     {
         return ! $this->option('commit') || $this->option('no-commit');
+    }
+
+    private function displaySemverOptions(): void
+    {
+        $data = [];
+
+        foreach (self::TYPES as $type) {
+            $process = Process::path(base_path())->run([
+                'bash', $this->getScriptPath('semver.sh'),
+                "--$type"
+            ]);
+
+            $data[] = [
+                'type' => ucwords($type),
+                'old' => $this->version,
+                'new' => trim($process->output())
+            ];
+
+        }
+
+        $this->table(['Type', 'Old', 'New'], $data);
     }
 }

--- a/src/Commands/Bump.php
+++ b/src/Commands/Bump.php
@@ -92,12 +92,14 @@ class Bump extends Command implements PromptsForMissingInput
     protected function promptForMissingArgumentsUsing(): array
     {
         return [
-            'type' => fn () => select(
-                label: 'Which semver segment would you like to bump?',
-                options: self::TYPES,
-                default: 'patch',
-                hint: 'E.g. major, minor or patch',
-            ),
+            'type' => function() {
+                return select(
+                    label: 'Which semver segment would you like to bump?',
+                    options: self::TYPES,
+                    default: 'patch',
+                    hint: 'E.g. major, minor or patch',
+                );
+            },
         ];
     }
 

--- a/src/Commands/Version.php
+++ b/src/Commands/Version.php
@@ -28,10 +28,13 @@ class Version extends Command implements PromptsForMissingInput
      */
     public function handle(): int
     {
-        $process = Process::path(base_path())->run("head -n 1 version.txt");
+        $this->info('v' . self::get());
 
-        $this->info('v' . $process->output());
+        return self::SUCCESS;
+    }
 
-        return $process->exitCode();
+    public static function get(): string
+    {
+        return file_get_contents(base_path('version.txt'));
     }
 }


### PR DESCRIPTION
- add displaying the current application version to 'php artisan bump' cli output
- add table display of semver bump types (and output version) when prompting for 'type' input