### PR TITLE
Cruise config for auto commit settings

### DIFF
--- a/src/Commands/Bump.php
+++ b/src/Commands/Bump.php
@@ -64,21 +64,23 @@ class Bump extends Command implements PromptsForMissingInput
         $this->info($message);
 
         // Exit process if bump failed or the 'commit' option is NOT enabled
-        if ($bumpProcess->failed() || $this->isCommitDisabled()) {
+        if ($bumpProcess->failed()) {
             return $bumpProcess->exitCode();
         }
 
-        // Run the commit process
-        $commitProcess = Process::path(base_path())->run([
-            'bash', $this->getScriptPath('commit.sh'),
-            $message
-        ]);
+        if ($this->isCommitEnabled()) {
+            // Run the commit process
+            $commitProcess = Process::path(base_path())->run([
+                'bash', $this->getScriptPath('commit.sh'),
+                $message
+            ]);
 
-        if ($commitProcess->failed()) {
-            return $commitProcess->exitCode();
+            if ($commitProcess->failed()) {
+                return $commitProcess->exitCode();
+            }
         }
 
-        return $bumpProcess->successful() && $commitProcess->successful() ? 1 : 0;
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Commands/Bump.php
+++ b/src/Commands/Bump.php
@@ -110,12 +110,16 @@ class Bump extends Command implements PromptsForMissingInput
 
     private function isCommitEnabled(): bool
     {
-        return $this->option('commit') || ! $this->option('no-commit');
+        if ($this->option('no-commit')) {
+            return false;
+        }
+
+        return $this->option('commit') || config('cruise.bump.auto-commit');
     }
 
     private function isCommitDisabled(): bool
     {
-        return ! $this->option('commit') || $this->option('no-commit');
+        return ! $this->isCommitEnabled();
     }
 
     private function displaySemverOptions(): void


### PR DESCRIPTION
- add checks to see if 'cruise.bump.auto-commit' is enabled when determining if version bumps should be committed
- improve control flow in `php artisan bump` command