### PR TITLE
Fix issue with 'composer build prod' not using produciton image name

### DIFF
--- a/scripts/runners/build.sh
+++ b/scripts/runners/build.sh
@@ -8,7 +8,6 @@ BRANCH="default"
 
 # Export Docker image Tag
 inside_git_repo="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
-
 if [ "$inside_git_repo" ]; then
 	BRANCH=$(git rev-parse --abbrev-ref HEAD)
 fi
@@ -19,9 +18,10 @@ export BRANCH
 
 # Build new containers
 if [[ "$ENV" == 'prod' ]]; then
-    # Retrieve the version number
-    VERSION="$(head -n 1 version.txt)"
-	docker build -t "${IMAGE}:${VERSION//}" .
+
+    # Extract the 'image' value for the 'app' service
+    IMAGE=$(grep -A 10 "services:" docker-compose.yml | grep -A 1 "app:" | grep "image:" | awk '{print $2}')
+	docker build -t "${IMAGE}" .
 else
     docker compose -f docker-compose-${ENV}.yml build
 fi


### PR DESCRIPTION
- fix issue with 'composer build prod' command not using the same image name as specified in docker-compose.yml