### PR TITLE
Add '--run' flag to 'composer start-test' command

### DIFF
--- a/scripts/runners/start-test.sh
+++ b/scripts/runners/start-test.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# Parse command arguments
+while :; do
+    case $1 in
+        -r|--run) run_tests=true
+        ;;
+        *) break
+    esac
+    shift
+done
+
 BRANCH="default"
 
 # Export Docker image Tag
@@ -27,4 +37,6 @@ docker exec app php artisan db:wait
 docker exec app php artisan migrate --seed
 
 # Run phpunit inside Docker 'app' container
-docker exec app ./vendor/bin/phpunit
+if [[ "$run_tests" == true ]]; then
+    docker exec app ./vendor/bin/phpunit
+fi


### PR DESCRIPTION
- add '--run' flag for running test suite after starting containers