### PR TITLE
Fix issue with 'php artisan db:wait' displaying negative values

### DIFF
--- a/src/Commands/WaitForDb.php
+++ b/src/Commands/WaitForDb.php
@@ -37,7 +37,7 @@ class WaitForDb extends Command
         foreach (range(1, $this->option('max-attempts')) as $attempt) {
             try {
                 DB::connection()->getPdo();
-                $time = now()->diffInSeconds($start);
+                $time = abs(now()->diffInSeconds($start));
                 $this->info("Took {$time} seconds to connect to the DB.");
 
                 return 0;


### PR DESCRIPTION
- add use of `abs()` function for making wait time a positive integer