### PR TITLE
'php artisan cruise:uninstall' command

### DIFF
--- a/src/Commands/CruiseInstall.php
+++ b/src/Commands/CruiseInstall.php
@@ -27,6 +27,9 @@ class CruiseInstall extends Command
      */
     public function handle(): int
     {
+        Artisan::call('vendor:publish', ['--tag' => 'cruise-config']);
+        $this->info('Published cruise config files config/cruise.php');
+
         Artisan::call('vendor:publish', ['--tag' => 'docker']);
         $this->info('Published docker assets to the application root');
 
@@ -47,10 +50,7 @@ class CruiseInstall extends Command
             $this->info('Published missing .env.dev.db file');
         }
 
-        Artisan::call('vendor:publish', ['--tag' => 'cruise-config']);
-        $this->info('Published cruise config files config/cruise.php');
-
-        return 0;
+        return self::SUCCESS;
     }
 
     private function addComposerScript(string $script): void

--- a/src/Commands/CruiseUninstall.php
+++ b/src/Commands/CruiseUninstall.php
@@ -72,7 +72,7 @@ class CruiseUninstall extends Command
     {
         $script_path = 'vendor/sfneal/cruise/scripts/runners';
 
-        (new Process(['composer', 'config', '--unset', "scripts.$script", "sh $script_path/$script.sh"]))->run();
+        (new Process(['composer', 'config', '--unset', "scripts.$script"]))->run();
 
         $this->info("Removed 'composer $script' command to composer.json");
     }

--- a/src/Commands/CruiseUninstall.php
+++ b/src/Commands/CruiseUninstall.php
@@ -70,8 +70,6 @@ class CruiseUninstall extends Command
 
     private function removeComposerScript(string $script): void
     {
-        $script_path = 'vendor/sfneal/cruise/scripts/runners';
-
         (new Process(['composer', 'config', '--unset', "scripts.$script"]))->run();
 
         $this->info("Removed 'composer $script' command to composer.json");

--- a/src/Commands/CruiseUninstall.php
+++ b/src/Commands/CruiseUninstall.php
@@ -65,16 +65,6 @@ class CruiseUninstall extends Command
         $this->removeComposerScript('build');
         $this->info('Removed composer scripts for starting/stopping docker services');
 
-        // Remove copied .env files
-        if (file_exists(base_path('.env.dev'))) {
-            unlink(file_exists(base_path('.env.dev')));
-            $this->info('Removed .env.dev file');
-        }
-        if (file_exists(base_path('.env.dev.db'))) {
-            unlink(file_exists(base_path('.env.dev.db')));
-            $this->info('Removed .env.dev.db file');
-        }
-
         return self::SUCCESS;
     }
 

--- a/src/Commands/CruiseUninstall.php
+++ b/src/Commands/CruiseUninstall.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Sfneal\Cruise\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
+
+class CruiseUninstall extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cruise:uninstall';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Uninstall the cruise package and remove publish files';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        // Remove config
+        if (File::exists(config_path('cruise.php'))) {
+            File::delete(config_path('cruise.php'));
+            $this->info('Removed cruise config files');
+        }
+
+        // Remove docker files
+        $docker_files = [
+            'changelog.txt',
+            'docker-compose.yml',
+            'docker-compose-dev.yml',
+            'docker-compose-dev-db.yml',
+            'docker-compose-dev-node.yml',
+            'docker-compose-tests.yml',
+            'Dockerfile',
+            'Dockerfile.dev',
+            'Dockerfile.dev.node',
+            'version.txt',
+        ];
+        $this->info('Removing docker related files...');
+        foreach ($docker_files as $file) {
+            $file_path = base_path($file);
+            if (File::exists($file_path)) {
+                File::delete($file_path);
+                $this->info("Removed {$file} from application root");
+            }
+        }
+
+        // Remove compose scripts
+        $this->removeComposerScript('start-dev');
+        $this->removeComposerScript('start-dev-db');
+        $this->removeComposerScript('start-dev-node');
+        $this->removeComposerScript('start-test');
+        $this->removeComposerScript('stop');
+        $this->removeComposerScript('build');
+        $this->info('Removed composer scripts for starting/stopping docker services');
+
+        // Remove copied .env files
+        if (file_exists(base_path('.env.dev'))) {
+            unlink(file_exists(base_path('.env.dev')));
+            $this->info('Removed .env.dev file');
+        }
+        if (file_exists(base_path('.env.dev.db'))) {
+            unlink(file_exists(base_path('.env.dev.db')));
+            $this->info('Removed .env.dev.db file');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function removeComposerScript(string $script): void
+    {
+        $script_path = 'vendor/sfneal/cruise/scripts/runners';
+
+        (new Process(['composer', 'config', '--unset', "scripts.$script", "sh $script_path/$script.sh"]))->run();
+
+        $this->info("Removed 'composer $script' command to composer.json");
+    }
+}

--- a/src/Providers/CruiseServiceProvider.php
+++ b/src/Providers/CruiseServiceProvider.php
@@ -5,6 +5,7 @@ namespace Sfneal\Cruise\Providers;
 use Illuminate\Support\ServiceProvider;
 use Sfneal\Cruise\Commands\Bump;
 use Sfneal\Cruise\Commands\CruiseInstall;
+use Sfneal\Cruise\Commands\CruiseUninstall;
 use Sfneal\Cruise\Commands\MigrateDbInProduction;
 use Sfneal\Cruise\Commands\Version;
 use Sfneal\Cruise\Commands\WaitForDb;
@@ -32,8 +33,9 @@ class CruiseServiceProvider extends ServiceProvider
                 Bump::class,
                 Version::class,
 
-                // Install command
+                // Install/uninstall command
                 CruiseInstall::class,
+                CruiseUninstall::class,
             ]);
         }
 


### PR DESCRIPTION
- add uninstall command for removing cruise assets from an application
- deletes docker files, configs & composer scripts