### PR TITLE
'php artisan cruise:uninstall' command to remove all docker assets

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,9 @@
+name: Update Changelog
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    uses: laravel/.github/.github/workflows/update-changelog.yml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-All notable changes to `cruise` will be documented in this file
+## v1.1.0 (2024-06-25)
+- Database command tests by @sfneal in #22
+- Semver Service by @sfneal in #24
+- Basic Documentation by @sfneal in #26
 
-## 0.1.0 - 2024-06-13
-- initial release
+
+## v1.0.0 (2024-06-24)
+- Initial release
+- 'php artisan cruise:uninstall' command by @sfneal in #17
+- Test Suite for testing commands by @sfneal in #19

--- a/src/Commands/CruiseUninstall.php
+++ b/src/Commands/CruiseUninstall.php
@@ -4,6 +4,7 @@ namespace Sfneal\Cruise\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 use Symfony\Component\Process\Process;
 
 class CruiseUninstall extends Command
@@ -54,6 +55,8 @@ class CruiseUninstall extends Command
                 $this->info("Removed {$file} from application root");
             }
         }
+        self::deleteFileTree(base_path('docker'));
+        $this->info("Removed 'docker' directory from application root");
 
         // Remove compose scripts
         $this->removeComposerScript('start-dev');
@@ -72,5 +75,18 @@ class CruiseUninstall extends Command
         (new Process(['composer', 'config', '--unset', "scripts.$script", '--working-dir='.base_path()]))->run();
 
         $this->info("Removed 'composer $script' command to composer.json");
+    }
+
+    private static function deleteFileTree(string $directory): void
+    {
+        foreach (array_diff(scandir($directory), ['.','..']) as $file) {
+            is_dir("$directory/$file")
+                ? self::deleteFileTree("$directory/$file")
+                : unlink("$directory/$file");
+
+        }
+
+        rmdir($directory);
+
     }
 }

--- a/tests/Unit/UninstallTest.php
+++ b/tests/Unit/UninstallTest.php
@@ -45,6 +45,9 @@ class UninstallTest extends TestCase
         foreach ($files as $file) {
             $this->assertFalse(File::exists(base_path(basename($file))));
         }
+
+        // Confirm docker assets were removed
+        $this->assertFalse(is_dir(base_path('docker')));
     }
 
     #[Test]


### PR DESCRIPTION
- add removing of the 'docker' directory to the cruise uninstall command