### PR TITLE
Cruise install command arguments & prompts

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -59,7 +59,7 @@ jobs:
             -   name: Install sfneal/cruise
                 working-directory: ../laravel-boilerplate-master
                 run: |
-                    php artisan cruise:install
+                    php artisan cruise:install mydockerid myapplication
 
             -   name: Test Downstream App
                 working-directory: ../laravel-boilerplate-master

--- a/cruise-app-test.sh
+++ b/cruise-app-test.sh
@@ -19,6 +19,6 @@ composer config repositories.0 '{"type": "vcs", "url": "https://github.com/sfnea
 
 composer require "sfneal/cruise dev-${CRUISE_BRANCH}"
 
-php artisan cruise:install
+php artisan cruise:install mydockerid myapplication
 
 # composer start-test

--- a/src/Commands/CruiseInstall.php
+++ b/src/Commands/CruiseInstall.php
@@ -4,7 +4,7 @@ namespace Sfneal\Cruise\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
-use Symfony\Component\Process\Process;
+use Illuminate\Support\Facades\Process;
 
 class CruiseInstall extends Command
 {
@@ -57,8 +57,16 @@ class CruiseInstall extends Command
     {
         $script_path = 'vendor/sfneal/cruise/scripts/runners';
 
-        (new Process(['composer', 'config', "scripts.$script", "sh $script_path/$script.sh", '--working-dir='.base_path()]))->run();
+        $process = Process::run([
+            'composer', 'config', "scripts.$script", "sh $script_path/$script.sh", '--working-dir='.base_path()
+        ]);
 
-        $this->info("Added 'composer $script' command to composer.json");
+        if ($process->successful()) {
+            $this->info("Added 'composer $script' command to composer.json");
+        }
+    }
+
+    private function renameApplication(string $name): void
+    {
     }
 }

--- a/src/Commands/CruiseInstall.php
+++ b/src/Commands/CruiseInstall.php
@@ -88,11 +88,13 @@ class CruiseInstall extends Command implements PromptsForMissingInput
             $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path('docker-compose-dev.yml'));
             $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path('docker-compose-dev-db.yml'));
             $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path('docker-compose-dev-node.yml'));
+            $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path('docker-compose-tests.yml'));
 
             $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose.yml')));
             $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose-dev.yml')));
             $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose-dev-db.yml')));
             $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose-dev-node.yml')));
+            $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose-tests.yml')));
         });
 
         if ($process->successful()) {

--- a/src/Commands/CruiseInstall.php
+++ b/src/Commands/CruiseInstall.php
@@ -92,8 +92,8 @@ class CruiseInstall extends Command implements PromptsForMissingInput
             ];
 
             foreach ($docker_compose_files as $docker_file) {
-                $pipe->path(base_path())->command("sed -i '' 's|$og_docker_id|$docker_id|g' ".$docker_file);
-                $pipe->path(base_path())->command(trim("sed -i '' 's|$og_image_name|$image_name|g' ".$docker_file));
+                $pipe->path(base_path())->command("sed -i'' 's|$og_docker_id|$docker_id|g' ".$docker_file);
+                $pipe->path(base_path())->command(trim("sed -i'' 's|$og_image_name|$image_name|g' ".$docker_file));
             }
         });
 

--- a/src/Commands/CruiseInstall.php
+++ b/src/Commands/CruiseInstall.php
@@ -90,9 +90,10 @@ class CruiseInstall extends Command implements PromptsForMissingInput
                 'docker-compose-dev-node.yml',
                 'docker-compose-tests.yml',
             ];
+
             foreach ($docker_compose_files as $docker_file) {
-                $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' ".base_path($docker_file));
-                $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' ".base_path($docker_file)));
+                $pipe->path(base_path())->command("sed -i '' 's|$og_docker_id|$docker_id|g' ".$docker_file);
+                $pipe->path(base_path())->command(trim("sed -i '' 's|$og_image_name|$image_name|g' ".$docker_file));
             }
         });
 

--- a/src/Commands/CruiseInstall.php
+++ b/src/Commands/CruiseInstall.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Process\Pipe;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Process;
-use function Laravel\Prompts\select;
+
 use function Laravel\Prompts\text;
 
 class CruiseInstall extends Command implements PromptsForMissingInput
@@ -66,7 +66,7 @@ class CruiseInstall extends Command implements PromptsForMissingInput
         $script_path = 'vendor/sfneal/cruise/scripts/runners';
 
         $process = Process::run([
-            'composer', 'config', "scripts.$script", "sh $script_path/$script.sh", '--working-dir='.base_path()
+            'composer', 'config', "scripts.$script", "sh $script_path/$script.sh", '--working-dir='.base_path(),
         ]);
 
         if ($process->successful()) {
@@ -92,16 +92,14 @@ class CruiseInstall extends Command implements PromptsForMissingInput
                 'docker-compose-tests.yml',
             ];
             foreach ($docker_compose_files as $docker_file) {
-                $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path($docker_file));
-                $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path($docker_file)));
+                $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' ".base_path($docker_file));
+                $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' ".base_path($docker_file)));
             }
         });
 
         if ($process->successful()) {
             $this->info("Renamed docker images from {$og_full_image_name} to {$docker_id}/{$image_name}");
-        }
-
-        else {
+        } else {
             $this->info("Failed to rename docker images from {$og_full_image_name} to {$docker_id}/{$image_name}");
         }
     }

--- a/src/Commands/CruiseInstall.php
+++ b/src/Commands/CruiseInstall.php
@@ -84,17 +84,17 @@ class CruiseInstall extends Command implements PromptsForMissingInput
             [$og_docker_id, $og_image_name] = explode('/', $og_full_image_name);
             $og_image_name = trim($og_image_name);
 
-            $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path('docker-compose.yml'));
-            $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path('docker-compose-dev.yml'));
-            $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path('docker-compose-dev-db.yml'));
-            $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path('docker-compose-dev-node.yml'));
-            $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path('docker-compose-tests.yml'));
-
-            $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose.yml')));
-            $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose-dev.yml')));
-            $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose-dev-db.yml')));
-            $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose-dev-node.yml')));
-            $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path('docker-compose-tests.yml')));
+            $docker_compose_files = [
+                'docker-compose.yml',
+                'docker-compose-dev.yml',
+                'docker-compose-dev-db.yml',
+                'docker-compose-dev-node.yml',
+                'docker-compose-tests.yml',
+            ];
+            foreach ($docker_compose_files as $docker_file) {
+                $pipe->command("sed -i '' 's|$og_docker_id|$docker_id|g' " . base_path($docker_file));
+                $pipe->command(trim("sed -i '' 's|$og_image_name|$image_name|g' " . base_path($docker_file)));
+            }
         });
 
         if ($process->successful()) {

--- a/src/Commands/CruiseInstall.php
+++ b/src/Commands/CruiseInstall.php
@@ -76,13 +76,12 @@ class CruiseInstall extends Command implements PromptsForMissingInput
 
     private function renameDockerImages(string $docker_id, string $image_name): void
     {
-        $og_full_image_name = Process::path(base_path())
+        $og_full_image_name = trim(Process::path(base_path())
             ->run("grep -A 10 'services:' docker-compose.yml | grep -A 1 'app:' | grep 'image:' | awk '{print $2}' | grep -o '^[^:]*'")
-            ->output();
+            ->output());
 
         $process = Process::pipe(function (Pipe $pipe) use ($og_full_image_name, $docker_id, $image_name) {
             [$og_docker_id, $og_image_name] = explode('/', $og_full_image_name);
-            $og_image_name = trim($og_image_name);
 
             $docker_compose_files = [
                 'docker-compose.yml',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,8 +8,12 @@ use Sfneal\Cruise\Providers\CruiseServiceProvider;
 
 class TestCase extends OrchestraTestCase
 {
+    const TEST_DOCKER_ID = 'fakedockerid';
+    const TEST_DOCKER_IMAGE = 'myapplication';
+
     protected bool $shouldInstall = true;
     protected bool $shouldUninstall = true;
+
 
     /**
      * Get package providers.
@@ -39,7 +43,7 @@ class TestCase extends OrchestraTestCase
         parent::setUp();
 
         if ($this->shouldInstall) {
-            $this->artisan('cruise:install');
+            $this->artisan('cruise:install', $this->getCruiseInstallArguments());
         }
     }
 
@@ -50,5 +54,13 @@ class TestCase extends OrchestraTestCase
         }
 
         parent::tearDown();
+    }
+
+    protected function getCruiseInstallArguments(): array
+    {
+        return [
+            'docker_id' => self::TEST_DOCKER_ID,
+            'docker_image' => self::TEST_DOCKER_IMAGE,
+        ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,7 +14,6 @@ class TestCase extends OrchestraTestCase
     protected bool $shouldInstall = true;
     protected bool $shouldUninstall = true;
 
-
     /**
      * Get package providers.
      *

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -8,7 +8,7 @@ use Sfneal\Cruise\Tests\TestCase;
 class ConfigTest extends TestCase
 {
     #[Test]
-    public function bump_auto_commit()
+    public function config_has_bump_auto_commit()
     {
         $output = config('cruise.bump.auto-commit');
 

--- a/tests/Unit/InstallTest.php
+++ b/tests/Unit/InstallTest.php
@@ -13,7 +13,7 @@ class InstallTest extends TestCase
     protected bool $shouldInstall = false;
 
     #[Test]
-    public function copies_the_configuration()
+    public function can_copy_the_configuration()
     {
         // make sure we're starting from a clean state
         if (File::exists(config_path('cruise.php'))) {
@@ -28,7 +28,7 @@ class InstallTest extends TestCase
     }
 
     #[Test]
-    public function copies_docker_assets()
+    public function can_copy_docker_assets()
     {
         // Get list of docker asset files
         $directory = __DIR__.'/../../docker/services';
@@ -54,7 +54,7 @@ class InstallTest extends TestCase
     }
 
     #[Test]
-    public function renames_docker_images()
+    public function can_rename_docker_images()
     {
         // Run install command
         Artisan::call('cruise:install', $this->getCruiseInstallArguments());
@@ -89,7 +89,7 @@ class InstallTest extends TestCase
     }
 
     #[Test]
-    public function adds_composer_commands()
+    public function can_add_composer_commands()
     {
         $expected_scripts = [
             'start-dev' => 'sh vendor/sfneal/cruise/scripts/runners/start-dev.sh',

--- a/tests/Unit/InstallTest.php
+++ b/tests/Unit/InstallTest.php
@@ -59,11 +59,20 @@ class InstallTest extends TestCase
         // Run install command
         Artisan::call('cruise:install', $this->getCruiseInstallArguments());
 
-        $image_name = trim(Process::path(base_path())
-            ->run("grep -A 10 'services:' docker-compose.yml | grep -A 1 'app:' | grep 'image:' | awk '{print $2}' | grep -o '^[^:]*'")
-            ->output());
+        $docker_files = [
+            'docker-compose.yml',
+            'docker-compose-dev.yml',
+            'docker-compose-dev-db.yml',
+            'docker-compose-dev-node.yml',
+            'docker-compose-tests.yml',
+        ];
+        foreach ($docker_files as $file) {
+            $image_name = trim(Process::path(base_path())
+                ->run("grep -A 10 'services:' {$file} | grep -A 10 'app:' | grep 'image:' | awk '{print $2}' | grep -o '^[^:]*'")
+                ->output());
 
-        $this->assertEquals(self::TEST_DOCKER_ID . '/' . self::TEST_DOCKER_IMAGE, $image_name);
+            $this->assertStringContainsString(self::TEST_DOCKER_ID . '/' . self::TEST_DOCKER_IMAGE, $image_name);
+        }
     }
 
     #[Test]

--- a/tests/Unit/InstallTest.php
+++ b/tests/Unit/InstallTest.php
@@ -71,7 +71,11 @@ class InstallTest extends TestCase
                 ->run("grep -A 10 'services:' {$file} | grep -A 10 'app:' | grep 'image:' | awk '{print $2}' | grep -o '^[^:]*'")
                 ->output());
 
-            $this->assertStringContainsString(self::TEST_DOCKER_ID.'/'.self::TEST_DOCKER_IMAGE, $image_name);
+            $this->assertStringContainsString(
+                self::TEST_DOCKER_ID.'/'.self::TEST_DOCKER_IMAGE,
+                $image_name,
+                "New Docker image name not found in {$file}"
+            );
         }
     }
 

--- a/tests/Unit/InstallTest.php
+++ b/tests/Unit/InstallTest.php
@@ -71,7 +71,7 @@ class InstallTest extends TestCase
                 ->run("grep -A 10 'services:' {$file} | grep -A 10 'app:' | grep 'image:' | awk '{print $2}' | grep -o '^[^:]*'")
                 ->output());
 
-            $this->assertStringContainsString(self::TEST_DOCKER_ID . '/' . self::TEST_DOCKER_IMAGE, $image_name);
+            $this->assertStringContainsString(self::TEST_DOCKER_ID.'/'.self::TEST_DOCKER_IMAGE, $image_name);
         }
     }
 

--- a/tests/Unit/UninstallTest.php
+++ b/tests/Unit/UninstallTest.php
@@ -12,7 +12,7 @@ class UninstallTest extends TestCase
     protected bool $shouldUninstall = false;
 
     #[Test]
-    public function removes_the_configuration()
+    public function can_remove_the_config()
     {
         $this->assertTrue(File::exists(config_path('cruise.php')));
 
@@ -22,7 +22,7 @@ class UninstallTest extends TestCase
     }
 
     #[Test]
-    public function removes_docker_assets()
+    public function can_remove_docker_assets()
     {
         // Get list of docker asset files
         $directory = __DIR__.'/../../docker/services';
@@ -51,7 +51,7 @@ class UninstallTest extends TestCase
     }
 
     #[Test]
-    public function adds_composer_commands()
+    public function can_remove_composer_commands()
     {
         $expected_scripts = [
             'start-dev' => 'sh vendor/sfneal/cruise/scripts/runners/start-dev.sh',


### PR DESCRIPTION
- add 'docker_id' & 'docker_image' arguments to 'php artisan cruise:install' command
- add functionality that renames docker images during cruise installation