### PR TITLE
Docker ignore file - prevent issues with Vite hot module reloading

### DIFF
--- a/docker/static/.dockerignore
+++ b/docker/static/.dockerignore
@@ -1,0 +1,6 @@
+.idea
+.git
+node_modules
+vendor
+scripts
+public/hot

--- a/src/Commands/CruiseUninstall.php
+++ b/src/Commands/CruiseUninstall.php
@@ -46,6 +46,7 @@ class CruiseUninstall extends Command
             'Dockerfile.dev.node',
             'version.txt',
             'vite.config.js',
+            '.dockerignore',
         ];
         $this->info('Removing docker related files...');
         foreach ($docker_files as $file) {

--- a/tests/Unit/InstallTest.php
+++ b/tests/Unit/InstallTest.php
@@ -68,6 +68,35 @@ class InstallTest extends TestCase
 
     #[Test]
     #[DataProvider('frontEndCompilersProvider')]
+    public function can_copy_static_assets(string $front_end_compiler)
+    {
+        // Get list of docker asset files
+        $directory = __DIR__.'/../../docker/static';
+        $files = [];
+        foreach (scandir($directory) as $file) {
+            if ($file !== '.' && $file !== '..') {
+                $files[] = $directory.'/'.$file;
+            }
+        }
+
+        // Confirm files DON'T already exist
+        foreach ($files as $file) {
+            $file_path = base_path(basename($file));
+            $this->assertFalse(File::exists($file_path), "The file '{$file_path}' already exists");
+        }
+
+        // Run install command
+        Artisan::call('cruise:install', $this->getCruiseInstallArguments($front_end_compiler));
+
+        // Confirm files DO exists
+        foreach ($files as $file) {
+            $file_path = base_path(basename($file));
+            $this->assertTrue(File::exists($file_path), "The file '{$file_path}' does not exists");
+        }
+    }
+
+    #[Test]
+    #[DataProvider('frontEndCompilersProvider')]
     public function can_rename_docker_images(string $front_end_compiler)
     {
         // Run install command


### PR DESCRIPTION
- add .dockerignore file to static docker assets used by both front-end compilers (Webpack & Vite)
- fix issue with hmr not working when running vite development server in Docker containers