### PR TITLE
Proxy container restarting & missing Docker volume

### DIFF
--- a/docker/services/vite/docker-compose-dev-db.yml
+++ b/docker/services/vite/docker-compose-dev-db.yml
@@ -49,6 +49,7 @@ services:
   proxy:
     image: stephenneal/nginx-proxy:1.27-alpine
     container_name: proxy
+    restart: unless-stopped
     volumes:
       - certs:/etc/letsencrypt
     environment:

--- a/docker/services/vite/docker-compose-dev-node.yml
+++ b/docker/services/vite/docker-compose-dev-node.yml
@@ -164,3 +164,4 @@ volumes:
   app:
   cache:
   certs:
+  public:

--- a/docker/services/vite/docker-compose-dev-node.yml
+++ b/docker/services/vite/docker-compose-dev-node.yml
@@ -75,6 +75,7 @@ services:
   proxy:
     image: stephenneal/nginx-proxy:1.27-alpine
     container_name: proxy
+    restart: unless-stopped
     volumes:
       - certs:/etc/letsencrypt
     environment:

--- a/docker/services/vite/docker-compose-dev.yml
+++ b/docker/services/vite/docker-compose-dev.yml
@@ -48,6 +48,7 @@ services:
   proxy:
     image: stephenneal/nginx-proxy:1.27-alpine
     container_name: proxy
+    restart: unless-stopped
     volumes:
       - certs:/etc/letsencrypt
     environment:

--- a/docker/services/webpack/docker-compose-dev-db.yml
+++ b/docker/services/webpack/docker-compose-dev-db.yml
@@ -51,6 +51,7 @@ services:
   proxy:
     image: stephenneal/nginx-proxy:1.26-alpine
     container_name: proxy
+    restart: unless-stopped
     volumes:
       - certs:/etc/letsencrypt
     environment:

--- a/docker/services/webpack/docker-compose-dev-node.yml
+++ b/docker/services/webpack/docker-compose-dev-node.yml
@@ -69,6 +69,7 @@ services:
   proxy:
     image: stephenneal/nginx-proxy:1.26-alpine
     container_name: proxy
+    restart: unless-stopped
     volumes:
       - certs:/etc/letsencrypt
     environment:

--- a/docker/services/webpack/docker-compose-dev.yml
+++ b/docker/services/webpack/docker-compose-dev.yml
@@ -50,6 +50,7 @@ services:
   proxy:
     image: stephenneal/nginx-proxy:1.26-alpine
     container_name: proxy
+    restart: unless-stopped
     volumes:
       - certs:/etc/letsencrypt
     environment:


### PR DESCRIPTION
- add 'restart: unless-stopped' param to 'proxy' Docker containers so that they automatically restart after dummy SSL certs have been created in development environments